### PR TITLE
Fix del not working on Windows

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -6,7 +6,7 @@
   "main": "desktop/build/index.js",
   "scripts": {
     "prepare": "remix setup node",
-    "clean": "del dist desktop/build public/build .cache",
+    "clean": "del-cli dist desktop/build public/build .cache",
     "dev": "npm run clean && cross-env NODE_ENV=development npm-run-all --parallel --print-label --race dev:*",
     "dev:remix": "remix watch",
     "dev:nodemon": "wait-on file:desktop/build/index.js && nodemon --watch desktop --ignore desktop/build --exec electron .",


### PR DESCRIPTION
As per `del-cli` readme: Windows users: Since $ del is already a builtin command on Windows, you need to use $ del-cli there.

Don't have an easy way to test this on mac/linux, but `del-cli` should hopefully work everywhere.