### PR TITLE
Improve request performance in dev

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,8 @@ import type { AssetFile } from "./asset-files"
 import { collectAssetFiles, serveAsset } from "./asset-files"
 import "./browser-globals"
 import { serveRemixResponse } from "./serve-remix-response"
+import { join } from "node:path"
+import { stat } from "node:fs/promises"
 
 const defaultMode = app.isPackaged ? "production" : process.env.NODE_ENV
 
@@ -53,15 +55,22 @@ export async function initRemix({
     app.whenReady(),
   ])
 
+  let lastBuildTime: number = 0;
+  let buildPath = typeof serverBuildOption === "string" ? join(serverBuildOption, 'index.js') : join(process.cwd(), 'desktop/build.js')
+
   protocol.interceptBufferProtocol("http", async (request, callback) => {
     try {
+      let buildTime = 0;
       if (mode === "development") {
         assetFiles = await collectAssetFiles(publicFolder)
+        let buildStat = await stat(buildPath)
+        buildTime = buildStat.mtimeMs;
       }
 
-      if (mode === "development" && typeof serverBuildOption === "string") {
+      if (mode === "development" && typeof serverBuildOption === "string" && lastBuildTime !== buildTime) {
         purgeRequireCache(asAbsolutePath(serverBuildOption))
         serverBuild = require(serverBuildOption)
+        lastBuildTime = buildTime;
       }
 
       const context = await getLoadContext?.(request)


### PR DESCRIPTION
When the server build gets larger it takes longer for `require(serverBuildOption)` to load it and process it. In my case where the build file was only around 1.8MB it took 150ms even though I have it on SSD. And since it's being re-required on every single request it can take even longer. In one of my routes I had fetcher that caused 3 requests thus taking around half a second for my click to get a result.

My quick solution is to check the build file changed time on every request and require it only when it changes. Ideally you'd require the build only when the remix server build version changes but afaik you can't access the server build info outside of remix.