### PR TITLE
fix electron.server.ts for remix v2...

### DIFF
--- a/template/app/electron.server.ts
+++ b/template/app/electron.server.ts
@@ -1,2 +1,5 @@
 import electron from "electron"
+import { installGlobals } from "@remix-run/node"
+
+installGlobals()
 export default electron


### PR DESCRIPTION
without globals, the root.tsx causes server fail with "[remix-electron] TypeError: Headers is not a constructor", so the template doesn't load. I believe this is about: see https://remix.run/docs/en/main/start/v2#installglobals
hence adding the globals lets the template's component load and render