### PR TITLE
fix: use decodeURIComponent to allow fetching public filenames that contain whitespaces

### DIFF
--- a/src/asset-files.cjs
+++ b/src/asset-files.cjs
@@ -10,7 +10,7 @@ const { createReadableStreamFromReadable } = require("@remix-run/node")
  */
 exports.serveAsset = async function serveAsset(request, publicFolder) {
 	const url = new URL(request.url)
-	const fullFilePath = path.join(publicFolder, url.pathname)
+	const fullFilePath = path.join(publicFolder, decodeURIComponent(url.pathname))
 	if (!fullFilePath.startsWith(publicFolder)) return
 
 	const stat = await fs.promises.stat(fullFilePath).catch(() => undefined)

--- a/tests/fixtures/test-app/public/with spaces.txt
+++ b/tests/fixtures/test-app/public/with spaces.txt
@@ -1,0 +1,1 @@
+This is a file with spaces in the path

--- a/tests/integration.test.mts
+++ b/tests/integration.test.mts
@@ -109,3 +109,15 @@ test.skip(
 	},
 	1000 * 30,
 )
+
+test("can load public assets that contain whitespace in their path", async () => {
+	const { window, dispose } = await launch()
+
+	await window.goto("http://localhost/with spaces.txt")
+
+	await expect(window.locator("body")).toHaveText(
+		"This is a file with spaces in the path",
+	)
+
+	await dispose()
+})


### PR DESCRIPTION
Fixes #23

