### PR TITLE
Use `import` instead of `require` to fix ESM Remix apps

### DIFF
--- a/workspaces/remix-electron/src/index.mts
+++ b/workspaces/remix-electron/src/index.mts
@@ -44,12 +44,12 @@ export async function initRemix({
 
 	const buildPath =
 		typeof serverBuildOption === "string"
-			? require.resolve(serverBuildOption)
+			? import.meta.resolve(serverBuildOption)
 			: undefined
 
 	let serverBuild =
 		typeof serverBuildOption === "string"
-			? /** @type {ServerBuild} */ require(serverBuildOption)
+			? /** @type {ServerBuild} */ await import(serverBuildOption)
 			: serverBuildOption
 
 	await app.whenReady()
@@ -86,7 +86,7 @@ export async function initRemix({
 			for await (const _event of watch(buildPath)) {
 				purgeRequireCache(buildPath)
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				serverBuild = require(buildPath)
+				serverBuild = await import(buildPath)
 				await broadcastDevReady(serverBuild)
 			}
 		})()


### PR DESCRIPTION
This is a (partial) fix for https://github.com/itsMapleLeaf/remix-electron/issues/28.

You might want to just use it as inspiration since this won't work for the `.cjs` build of this package. Or maybe it's time to drop the `.cjs` build, considering the Remix templates are ESM at this point.

I also didn't try the dev mode, but I'm sure the purging of the require cache doesn't work correctly with this change. Not sure how to do that when using `import` (https://github.com/nodejs/node/issues/49442).