### PR TITLE
Switch to MIT license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "remix-electron-monorepo",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"build": "pnpm run -r --filter ./workspaces/remix-electron build",

--- a/workspaces/remix-electron/package.json
+++ b/workspaces/remix-electron/package.json
@@ -3,7 +3,7 @@
 	"version": "2.0.2",
 	"author": "itsMapleLeaf",
 	"description": "Electron integration for Remix",
-	"license": "GPL-3.0+",
+	"license": "MIT",
 	"repository": "https://github.com/itsMapleLeaf/remix-electron",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/workspaces/template/package.json
+++ b/workspaces/template/package.json
@@ -2,6 +2,7 @@
 	"name": "remix-electron-template",
 	"description": "",
 	"version": "0.0.0",
+	"license": "MIT",
 	"private": true,
 	"main": "desktop/index.js",
 	"scripts": {

--- a/workspaces/test-app/package.json
+++ b/workspaces/test-app/package.json
@@ -2,6 +2,7 @@
 	"name": "remix-electron-test-app",
 	"version": "0.0.0",
 	"private": true,
+	"license": "MIT",
 	"main": "desktop/index.js",
 	"scripts": {
 		"dev": "remix dev --manual --command \"nodemon .\"",

--- a/workspaces/tests/package.json
+++ b/workspaces/tests/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "remix-electron-tests",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"test": "playwright test"


### PR DESCRIPTION
@itsMapleLeaf as discussed on Discord, this first pr changes the license to MIT otherwise using remix-electron in apps can be hard or impossible since GPL3+ requires same licensing and open sourcing. Will follow up with other changes.